### PR TITLE
Adding clang support, plus some fixes regarding constexpr

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -8,11 +8,16 @@ enable_testing()
 
 option(BUILD_DOCUMENTATION "Create and install the HTML based API documentation (requires Doxygen)" OFF)
 
+string(COMPARE EQUAL ${CMAKE_CXX_COMPILER_ID} "GNU" USING_GCC)
+string(COMPARE EQUAL ${CMAKE_CXX_COMPILER_ID} "Clang" USING_CLANG)
+
 find_program(GCOV gcov)
 find_program(LCOV lcov)
 find_program(GCOVR gcovr)
 find_program(GENHTML genhtml)
 find_program(CPPCHECK cppcheck)
+find_program(VALGRIND valgrind)
+
 find_package(Doxygen)
 find_package(Boost ${MINIMUM_BOOST_VERSION} COMPONENTS program_options regex REQUIRED)
 
@@ -23,7 +28,12 @@ file(GLOB TEST_SRC ${CMAKE_CURRENT_SOURCE_DIR}/src/test*.cxx)
 
 add_executable(${PROJECT_NAME} src/main.cxx ${TEST_SRC})
 target_link_libraries(${PROJECT_NAME} ${Boost_LIBRARIES})
-target_link_libraries(${PROJECT_NAME} stdc++)
+
+# We don't need to explictly link standard library when using clang
+if(!USING_CLANG)
+    target_link_libraries(${PROJECT_NAME} stdc++)
+endif(!USING_CLANG)
+
 add_test(test ${PROJECT_NAME})
 
 if(LCOV)
@@ -36,8 +46,19 @@ endif(GCOVR)
 
 if(GCOV)
     message("-- Found GCOV: ${GCOV}")
-    add_definitions("--coverage -fprofile-arcs -ftest-coverage")
-    target_link_libraries(${PROJECT_NAME} gcov)
+    set(COVERAGE_FLAGS "-fprofile-arcs -ftest-coverage")
+    # Setting up gcc coverage flags and libraries
+    if(USING_GCC)
+        string(CONCAT COVERAGE_FLAGS "--coverage " ${COVERAGE_FLAGS})
+        target_link_libraries(${PROJECT_NAME} gcov)
+    endif(USING_GCC)
+    # Setting up clang coverage linger flags
+    if(USING_CLANG)
+        string(CONCAT PROFILE_LINK_FLAGS ${LINK_FLAGS} ${COVERAGE_FLAGS})
+        set_target_properties(${PROJECT_NAME} PROPERTIES LINK_FLAGS ${PROFILE_LINK_FLAGS})
+    endif(USING_CLANG)
+    # Adding definitions
+    add_definitions(${COVERAGE_FLAGS})
 endif(GCOV)
 
 if(GENHTML)
@@ -47,6 +68,10 @@ endif(GENHTML)
 if(CPPCHECK)
     message("-- Found CPPCHECK: ${CPPCHECK}")
 endif(CPPCHECK)
+
+if(VALGRIND)
+    message("-- Found VALGRIND: ${VALGRIND}")
+endif(VALGRIND)
 
 install(DIRECTORY include/math         DESTINATION include/${PROJECT_NAME})
 install(DIRECTORY include/pattern      DESTINATION include/${PROJECT_NAME})
@@ -88,14 +113,18 @@ endif(BUILD_DOCUMENTATION)
 # check command workaround that 'test' does not build the binary.
 add_custom_target(check COMMAND ${CMAKE_CTEST_COMMAND} DEPENDS ${PROJECT_NAME})
 add_custom_target(run COMMAND ${PROJECT_NAME} DEPENDS ${PROJECT_NAME})
-add_custom_target(memcheck COMMAND valgrind --leak-check=full ${CMAKE_BINARY_DIR}/${PROJECT_NAME}
-                  DEPENDS ${PROJECT_NAME})
+
+if(VALGRIND)
+    add_custom_target(memcheck COMMAND valgrind --leak-check=full ${CMAKE_BINARY_DIR}/${PROJECT_NAME}
+                      DEPENDS ${PROJECT_NAME})
+endif(VALGRIND)
+
 add_custom_target(clear-coverage
     COMMAND find ${CMAKE_BINARY_DIR} -name "*.gcno" | xargs -i rm -f {}
     COMMAND find ${CMAKE_BINARY_DIR} -name "*.gcda" | xargs -i rm -f {})
 
 if(GCOV AND LCOV AND GENHTML AND GCOVR)
-    add_custom_target(coverage 
+    add_custom_target(coverage
            COMMAND mkdir -p ${CMAKE_BINARY_DIR}/coverage
            COMMAND ${LCOV} --capture
                            --no-external
@@ -124,6 +153,4 @@ if(CPPCHECK)
                             --std=c++11
                             ${CMAKE_CURRENT_SOURCE_DIR})
 endif(CPPCHECK)
-
-
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -49,12 +49,12 @@ if(GCOV)
     set(COVERAGE_FLAGS "-fprofile-arcs -ftest-coverage")
     # Setting up gcc coverage flags and libraries
     if(USING_GCC)
-        string(CONCAT COVERAGE_FLAGS "--coverage " ${COVERAGE_FLAGS})
+        set(COVERAGE_FLAGS "--coverage ${COVERAGE_FLAGS}")
         target_link_libraries(${PROJECT_NAME} gcov)
     endif(USING_GCC)
     # Setting up clang coverage linger flags
     if(USING_CLANG)
-        string(CONCAT PROFILE_LINK_FLAGS ${LINK_FLAGS} ${COVERAGE_FLAGS})
+        set(PROFILE_LINK_FLAGS "${LINK_FLAGS} ${COVERAGE_FLAGS}")
         set_target_properties(${PROJECT_NAME} PROPERTIES LINK_FLAGS ${PROFILE_LINK_FLAGS})
     endif(USING_CLANG)
     # Adding definitions

--- a/include/algorithm/shuffled.h
+++ b/include/algorithm/shuffled.h
@@ -24,6 +24,7 @@
 #define INCLUDE_SHUFFLE_H_
 
 #include <algorithm>
+#include <random>
 
 namespace algorithm {
 

--- a/include/math/big_integer.h
+++ b/include/math/big_integer.h
@@ -54,7 +54,7 @@ class big_integer {
         /// @return this to allow to continue with further operations.
         /// @note for the moment we create an implementation each call
         ///       which will be changed.
-        const big_integer& operator += (const big_integer& rhs) noexcept {
+        const big_integer& operator += (const big_integer& rhs) {
             auto operation = factory::get().create_instance(int(big_integer_operation::SUM));
             if (!operation) {
                 throw std::runtime_error("Missing SUM implementation!");

--- a/include/math/line.h
+++ b/include/math/line.h
@@ -51,7 +51,7 @@ class line final {
         }
 
         /// length of line
-        constexpr double length() const noexcept {
+        double length() noexcept {
             return m_direction.length();
         }
 

--- a/include/math/vector.h
+++ b/include/math/vector.h
@@ -67,7 +67,7 @@ class vector final {
         }
 
         /// providing normed vector
-        constexpr vector normed() const noexcept {
+        vector normed() noexcept {
             return vector(m_x / length(), m_y / length());
         }
 

--- a/include/math/vector.h
+++ b/include/math/vector.h
@@ -47,7 +47,7 @@ class vector final {
         }
 
         /// length of vector
-        constexpr double length() const noexcept {
+        double length() const noexcept {
             return sqrt(m_x * m_x + m_y * m_y);
         }
 
@@ -76,7 +76,8 @@ class vector final {
             return vector(m_x * factor, m_y * factor);
         }
 
-        constexpr double angle(const vector& other) const {
+        /// providing angle between two vectors
+        double angle(const vector& other) const {
             return (180.0/M_PI) * acos(scalar_product(other) / (length() * other.length()));
         }
 

--- a/include/unittest/options.h
+++ b/include/unittest/options.h
@@ -23,6 +23,7 @@
 #ifndef INCLUDE_UNTTEST_OPTIONS_H_
 #define INCLUDE_UNTTEST_OPTIONS_H_
 
+#include <iostream>
 #include <boost/program_options.hpp>
 
 namespace unittest {

--- a/src/test_line.cxx
+++ b/src/test_line.cxx
@@ -50,7 +50,7 @@ describe_suite("testing math::line", [](){
 
     /// testing @ref math::line::length
     describe_test("testing line length", []() {
-        const math::line l{math::vector{1.0, 2.0}, math::vector{3.0, 4.0}};
+        math::line l{math::vector{1.0, 2.0}, math::vector{3.0, 4.0}};
         assert_that(5.0, is_equal(l.length()));
     });
 

--- a/src/test_performance.cxx
+++ b/src/test_performance.cxx
@@ -28,6 +28,7 @@
 using namespace unittest;
 using namespace matcher;
 
+// This suite directly depends on CPU power!!!
 describe_suite("testing performance functions", [](){
     describe_test("testing performance::measure (milliseconds)", []() {
         const auto duration = performance::measure<std::milli>([]() {
@@ -35,7 +36,7 @@ describe_suite("testing performance functions", [](){
             std::this_thread::sleep_for(std::chrono::duration<double, std::milli>(100));
         });
 
-        assert_that(duration, is_range(100.0, 103.0));
+        assert_that(duration, is_range(100.0, 105.0));
     });
 
     describe_test("testing performance::measure (microseconds)", []() {
@@ -44,7 +45,7 @@ describe_suite("testing performance functions", [](){
             std::this_thread::sleep_for(std::chrono::duration<double, std::milli>(100));
         });
 
-        assert_that(duration, is_range(100000.0, 103000.0));
+        assert_that(duration, is_range(100000.0, 105000.0));
     });
 
     describe_test("testing performance::measure (seconds)", []() {
@@ -53,7 +54,7 @@ describe_suite("testing performance functions", [](){
             std::this_thread::sleep_for(std::chrono::duration<double, std::milli>(100));
         });
 
-        assert_that(duration, is_range(0.100, 0.103));
+        assert_that(duration, is_range(0.100, 0.105));
     });
 });
 

--- a/src/test_vector.cxx
+++ b/src/test_vector.cxx
@@ -77,7 +77,7 @@ describe_suite("testing math::vector", [](){
     });
 
     describe_test("testing normed vector", []() {
-        const math::vector v1 = {3.0, 4.0};
+        math::vector v1 = {3.0, 4.0};
         assert_that(math::vector(0.6, 0.8), is_equal(v1.normed()));
     });
 


### PR DESCRIPTION
The following features are added:
- Added support for clang compiler family
- The memcheck target is now added only if valgrind is present

The following issues were corrected:
- On couple of places there was a call from constexpr functions to a non constexpr, while gcc is fine with that, more strict compilers do not allow this. Also, this is not allowed by standard too.
- One method was declared as noexcept, but it was throwing an exception
- The test suite for performance testing directly depends on CPU power. The range is now extended, but some other way of testing needs to be devised.
